### PR TITLE
feat: add workflow auto release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: lts/*
+
+      - run: npx changelogithub # or changelogithub@0.12 if ensure the stable result
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# 🚀 Description
This MR introduces a new GitHub Actions Release workflow to automate the release process when a new version tag (v*) is pushed to the repository.

# 🔧 What it does
- Triggers on: Git tag pushes (e.g. v1.0.0) and manual dispatch via GitHub UI
- Generates changelog based on commit messages (feat, fix, refactor, etc.)
- Credits contributors automatically
- Uses [changelogithub](https://github.com/antfu/changelogithub) to generate GitHub releases with categorized commits and contributor list

# 📸 Example Output
Below is an example of the release output:

> ![image](https://github.com/user-attachments/assets/d0035774-c47b-42f8-8a45-6736472c9cc3)
